### PR TITLE
chmod target file to make it world-readable

### DIFF
--- a/pokemon.c
+++ b/pokemon.c
@@ -1,4 +1,4 @@
-// $ echo pikachu|sudo tee pokeball;ls -l pokeball;gcc -pthread pokemon.c -o d;./d pokeball miltank;cat pokeball
+// $ echo pikachu|sudo tee pokeball;sudo chmod 0404 pokeball;ls -l pokeball;gcc -pthread pokemon.c -o d;./d pokeball miltank;cat pokeball
 #include <fcntl.h>                        //// pikachu
 #include <pthread.h>                      //// -rw-r--r-- 1 root root 8 Apr 4 12:34 pokeball
 #include <string.h>                       //// pokeball


### PR DESCRIPTION
On my machine, the umask for root makes it so that pokeball is not readable by world. 
The last command, "cat pokeball" will fail lacking permission.

So the test should include a "chmod 0404 pokeball". dirtyc0w.c does it. 

Also. The exploit seems to depend on the user having read access to the file. From a user session, I was looping "./d pokeball miltank" repeatedly and in a root session, cat-ing the file and it never changed to miltank. 

